### PR TITLE
show time it takes to compile Stylus file (bug 1091421)

### DIFF
--- a/main.js
+++ b/main.js
@@ -98,6 +98,7 @@ gulp.task('templates_build_sync', function() {
 function css_compile_pipe(stream) {
     // Compile .styl files into .styl.css files.
     // Takes about 2s to compile all CSS files.
+    var startTime = new Date().getTime();
     return stream
         .pipe(stylus())
         .on('error', function(err) {
@@ -107,7 +108,16 @@ function css_compile_pipe(stream) {
         .pipe(rename(function(path) {
             path.extname = '.styl.css';
         }))
-        .pipe(gulp.dest(config.CSS_DEST_PATH));
+        .pipe(gulp.dest(config.CSS_DEST_PATH))
+        .pipe(eventStream.map(function(file) {
+            // TODO: Figure out where the logging and `startTime` should go.
+            // `stream.on('end')` is wrong because the stream gets chunked.
+            gulpUtil.log(gulpUtil.colors.magenta(path.basename(file.path)),
+                'was compiled in',
+                gulpUtil.colors.magenta(
+                    new Date().getTime() - startTime + ' ms'));
+            startTime = new Date().getTime();
+        }));
 }
 
 


### PR DESCRIPTION
notice that the times are not accurate for the files compiled when `make serve` starts up. but the times look good when Stylus files get rebuilt during the file watching.

and I know I'm not doing this correctly. guidance please, @ngokevin? thanks.

![screenshot 2014-10-30 22 28 45](https://cloud.githubusercontent.com/assets/203725/4856642/27527876-60bf-11e4-8fef-15913a52a362.png)
![screenshot 2014-10-30 22 25 47](https://cloud.githubusercontent.com/assets/203725/4856643/27579ee6-60bf-11e4-9ccc-1484251247cb.png)
