### PR TITLE
use r.js proper rather than amd-optimize (bug 1092718, 1078093)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "author": "Mozilla",
   "name": "marketplace-gulp",
-  "version": "1.0.93",
+  "version": "1.0.94",
   "ignore": [
     "bower.json",
     "LICENSE",

--- a/paths.js
+++ b/paths.js
@@ -12,8 +12,6 @@ var paths = {
     js: [config.JS_DEST_PATH + '**/*.js', 'src/templates.js'],
 };
 paths.require = paths.bower + 'requirejs/require.js';
-paths.almond = paths.bower + 'almond/almond.js';
-paths.init = paths.bower + 'commonplace/dist/core/init.js';
 paths.styl = [config.CSS_DEST_PATH + '**/*.styl', '!' + paths.styl_lib];
 
 module.exports = paths;


### PR DESCRIPTION
using rjs is so much easier and powerful. It's Gulp's recommended way to build require projects. At first I went with gulp-requirejs which was a bad idea since it was blacklisted and didn't mesh gulp+rjs well. Then I went with amd-optimize which doesn't have enough features. So rjs does everything for us.
- Handles including modules like almond without concatting
- Allows an insertRequire so we don't need init.js
- Handles source maps easily
- Removes views/tests easily while stubbing, reducing our include.js size by a tiny bit
