### PR TITLE
Remove redundant command in 'make init' has been removed. Use 'make install' instead. deprecation message.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean:
 	@node_modules/.bin/gulp clean
 
 init:
-	@echo "'make init' has been removed. Use 'npm install && make install' instead."
+	@echo "'make init' has been removed. Use 'make install' instead."
 
 update:
 	@echo "'make update' has been removed. Use 'make install' instead."


### PR DESCRIPTION
`npm install` is already [part of `make install`](https://github.com/mozilla/marketplace-gulp/blob/aa875481b131d8bd81b5a10e3fd2b9e86ff6dbe1/Makefile#L11), no need to run both.

r? @ngokevin 