### PR TITLE
Reduce CPU due to overlapping watches

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,7 +271,8 @@ gulp.task('js_build', ['templates_build_sync'], function() {
 });
 
 
-var nunjucksEnv= new nunjucks.Environment(new nunjucks.FileSystemLoader('src'));
+// The second arg to FileSystemLoader is noWatch. It is set to true to disable watching.
+var nunjucksEnv= new nunjucks.Environment(new nunjucks.FileSystemLoader('src', true));
 gulp.task('index_html_build', function() {
     // Run Nunjucks templating on desired template.
     // Passing in MKT_COMPILED will use compressed assets in dev.html.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marketplace-gulp",
   "description": "gulpfiles for Firefox Marketplace frontend projects",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "main": "index",
   "repository": {
     "url": "git://github.com/mozilla/marketplace-gulp.git",


### PR DESCRIPTION


Gulp in the fireplace container is consuming ~170%+ CPU under docker. (This actually results in VirtualBoxHeadless eating even more CPU under the host)

It looks to be caused by overlapping watches from gulp + nunjucks. The dev.html -> index.html is watched + built here https://github.com/mozilla/marketplace-gulp/blob/master/index.js#L387 a new nunjucks env causes the templates to be watched by nunjucks by default.

Doing this seems to also benefits non-docker usage as I see the node CPU usage drop from ~20% to ~4%.

Before:

![1__top](https://cloud.githubusercontent.com/assets/1514/5761157/6619bec2-9cd1-11e4-8579-6bd2223cfb61.png)

After:

![1__top](https://cloud.githubusercontent.com/assets/1514/5761166/73c4dd40-9cd1-11e4-8005-833d53d3ab95.png)

