### PR TITLE
Init built JS with core/init

### DIFF
--- a/index.js
+++ b/index.js
@@ -288,7 +288,7 @@ function jsBuild(overrideConfig, cb) {
         generateSourceMaps: true,
         include: ['lib/almond', 'main'].concat(viewFiles)
                                        .concat(coreViewFiles),
-        insertRequire: ['main'],
+        insertRequire: ['core/init'],
         paths: _.extend(config.requireConfig.paths,
                         config.requireConfig.buildPaths),
         preserveLicenseComments: false,


### PR DESCRIPTION
This is needed for https://github.com/mozilla/marketplace-core-modules/pull/29 to manage loading main instead of main loading init.