### PR TITLE
Ignore `templates/tests.html`.

### DIFF
--- a/paths.js
+++ b/paths.js
@@ -6,7 +6,7 @@ var paths = {
     styl_compiled: config.CSS_DEST_PATH + '**/*.styl.css',
     styl_lib: [config.CSS_DEST_PATH + 'lib.styl',
                config.CSS_DEST_PATH + 'lib/**/*.styl'],
-    html: 'src/templates/**/*.html',
+    html: ['src/templates/**/*.html', '!src/templates/**/tests.html'],
     include_css: 'include.css',
     include_js: 'include.js',
     index_html: ['src/*.html', '!src/index.html'],


### PR DESCRIPTION
Ignores `templates/**/tests.html` in order to not minify it with the rest of the production code.

Fixes bug [1042858](https://bugzilla.mozilla.org/show_bug.cgi?id=1042858).