### PR TITLE
v3.2.0 build step for l10n_init.js (bug 1044195)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.sw[pon]
 node_modules
+npm-debug.log

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ var rewriteModule = require('http-rewrite-middleware');
 var rjs = require('requirejs');
 var stylus = require('gulp-stylus');
 var through2 = require('through2');
+var uglify = require('gulp-uglify');
 var watch = require('gulp-watch');
 var webserver = require('gulp-webserver');
 var _ = require('underscore');
@@ -67,6 +68,7 @@ if (process.env.API) {
     console.log('    media_url: ' + api.media_url);
 }
 
+
 gulp.task('settings_local_js_init', function() {
     // Creates a settings_local.js if it doesn't exist.
     fs.exists(config.JS_DEST_PATH + 'settings_local.js', function(exists) {
@@ -93,6 +95,14 @@ gulp.task('require_config', function() {
     gulp.src(paths.require)
         .pipe(insert.append(config.inlineRequireConfig))
         .pipe(gulp.dest(config.LIB_DEST_PATH));
+});
+
+
+gulp.task('l10n_init_js_build', function() {
+    gulp.src(config.BOWER_PATH + 'marketplace-core-modules/core/l10n_init.js')
+        .pipe(rename('l10n.js'))
+        .pipe(uglify())
+        .pipe(gulp.dest(config.JS_DEST_PATH));
 });
 
 
@@ -432,10 +442,12 @@ gulp.task('serve', ['webserver', 'css_compile', 'templates_build']);
 gulp.task('default', ['watch', 'serve']);
 
 gulp.task('update', ['settings_local_js_init', 'bower_copy',
-                     'index_html_build', 'require_config']);
+                     'index_html_build', 'require_config',
+                     'l10n_init_js_build']);
 
 gulp.task('build', ['buildID_write', 'css_build_sync', 'js_build',
-                    'templates_build_sync', 'imgurls_write']);
+                    'templates_build_sync', 'imgurls_write',
+                    'l10n_init_js_build']);
 
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "marketplace-gulp",
   "description": "gulpfiles for Firefox Marketplace frontend projects",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "main": "index",
   "repository": {
     "url": "git://github.com/mozilla/marketplace-gulp.git",
@@ -28,6 +28,7 @@
     "gulp-rename": "1.2.0",
     "gulp-replace": "0.4.0",
     "gulp-stylus": "2.0.1",
+    "gulp-uglify": "1.1.x",
     "gulp-util": "3.0.x",
     "gulp-watch": "1.1.0",
     "gulp-webserver": "0.9.0",


### PR DESCRIPTION
https://github.com/mozilla/marketplace-core-modules/pull/30

we can think about removing the copy step once all projects are up-to-date with l10n.js